### PR TITLE
[OG04] ListItem 컴포넌트 및 스토리 구현

### DIFF
--- a/src/components/molecules/ExplainBox/ExplainBox.tsx
+++ b/src/components/molecules/ExplainBox/ExplainBox.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import styled, { css } from 'styled-components';
 import ExplainText from '../../atoms/ExplainText/ExplainText';
 import SubTitle from '../../atoms/SubTitle/SubTitle';
@@ -10,11 +10,16 @@ interface Props {
 
 const ExplainBox = ({ label, children }: Props) => {
   return (
-    <Fragment>
+    <Container>
       <SubTitle label={label} />
       <ExplainText children={children} />
-    </Fragment>
+    </Container>
   );
 };
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
 
 export default ExplainBox;

--- a/src/components/organisms/ListItem/ListItem.stories.tsx
+++ b/src/components/organisms/ListItem/ListItem.stories.tsx
@@ -1,0 +1,20 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import ListItem from './ListItem';
+import thumbnail from '../../../assets/thumbnail.svg';
+
+export default {
+  title: 'Organisms/ListItem',
+  component: ListItem,
+} as ComponentMeta<typeof ListItem>;
+
+const Template: ComponentStory<typeof ListItem> = args => (
+  <ListItem {...args} />
+);
+
+export const list_item = Template.bind({});
+list_item.args = {
+  label: 'Top 10 UX Design Courses',
+  children:
+    'Do you want to start a career in UX Design?  Check the top courses that will help you learn the skills.',
+  src: thumbnail,
+};

--- a/src/components/organisms/ListItem/ListItem.tsx
+++ b/src/components/organisms/ListItem/ListItem.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from 'styled-components';
+import Image from '../../atoms/Image/Image';
+
+import ExplainBox from '../../molecules/ExplainBox/ExplainBox';
+
+interface Props {
+  label: string;
+  children: string;
+  src: string;
+}
+
+const ListItem = ({ src, label, children }: Props) => {
+  return (
+    <Container>
+      <Image src={src} small />
+      <ExplainBox label={label} children={children} />
+    </Container>
+  );
+};
+
+export default ListItem;
+
+const Container = styled.div`
+  border: 2px solid #000000;
+  border-radius: 8px;
+  display: flex;
+  padding 24px;
+  box-sizing: border-box;
+  align-items: center;
+  gap: 24px;
+`;


### PR DESCRIPTION
* ListItem을 구현하던 중 ExplainText 컴포넌트의 레이아웃 부분을 Fragment로 작성해 1열로 배치가 안되던 것을 Container를 선언해 레이아웃으로 감싸주고, 어디서나 1열로 배치가 되도록 수정했습니다.